### PR TITLE
Pin toil to known working version 3.6.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN cd /opt/ \
 #Toil#
 ######
 RUN pip install --upgrade pip \
-    && pip install toil[cwl] \
+    && pip install toil[cwl]==3.6.0 \
     && sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
 
 # Define a timezone so Java works properly


### PR DESCRIPTION
The 3.7.0 release has broken LSF support.

(This is the same as genome/docker-cle#34.)

