### PR TITLE
Upgrade toil to 3.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,11 @@ RUN cd /opt/ \
 ######
 RUN pip install --upgrade pip \
     && pip install toil[cwl]==3.12.0 \
+    && cd /tmp/ \
+    && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsfHelper.py \
+    && mv -f lsfHelper.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ \
+    && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsf.py \
+    && mv -f lsf.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ \
     && sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
 
 # Define a timezone so Java works properly

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN cd /opt/ \
 #Toil#
 ######
 RUN pip install --upgrade pip \
-    && pip install toil[cwl]==3.6.0 \
+    && pip install toil[cwl]==3.12.0 \
     && sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
 
 # Define a timezone so Java works properly


### PR DESCRIPTION
Same story as genome/docker-cle#63 and genome/docker-rnaseq#4.